### PR TITLE
More test and improvements - fix issues with icons in maya dock.

### DIFF
--- a/vfxwindow/__init__.py
+++ b/vfxwindow/__init__.py
@@ -17,7 +17,7 @@ TODO:
 from __future__ import absolute_import
 
 __all__ = ['VFXWindow']
-__version__ = '1.8.0'
+__version__ = '1.9.0'
 
 import sys
 from .utils import software

--- a/vfxwindow/__init__.py
+++ b/vfxwindow/__init__.py
@@ -20,7 +20,7 @@ __all__ = ['VFXWindow']
 __version__ = '1.9.0'
 
 import sys
-from .utils import software
+from .utils import application
 from . import exceptions
 
 
@@ -38,14 +38,14 @@ def _setup_qapp():
         pass
 
 
-if software.isMayaBatch():
+if application.isMayaBatch():
     _setup_qapp()
     from .maya import MayaBatchWindow as VFXWindow
 
-elif software.isMaya():
+elif application.isMaya():
     from .maya import MayaWindow as VFXWindow
 
-elif software.isNuke():
+elif application.isNuke():
     from .nuke import runningInTerminal
 
     inTerminal = runningInTerminal(startup=True)
@@ -57,28 +57,28 @@ elif software.isNuke():
     else:
         from .nuke import NukeWindow as VFXWindow
 
-elif software.isHoudini():
+elif application.isHoudini():
     from .houdini import HoudiniWindow as VFXWindow
 
-elif software.isBlender():
+elif application.isBlender():
     from .blender import BlenderWindow as VFXWindow
 
-elif software.isUnrealEngine():
+elif application.isUnrealEngine():
     from .unreal import UnrealWindow as VFXWindow
 
-elif software.is3dsMax():
+elif application.is3dsMax():
     from .max import MaxWindow as VFXWindow
 
-elif software.isSubstanceDesigner():
+elif application.isSubstanceDesigner():
     from .substance_designer import SubstanceDesignerWindow as VFXWindow
 
-elif software.isSubstancePainter():
+elif application.isSubstancePainter():
     from .substance_painter import SubstancePainterWindow as VFXWindow
 
-elif software.isBlackmagicFusion():
+elif application.isBlackmagicFusion():
     from .fusion import FusionWindow as VFXWindow
 
-elif software.isCryEngine():
+elif application.isCryEngine():
     from .cryengine import CryWindow as VFXWindow
 
 else:

--- a/vfxwindow/abstract.py
+++ b/vfxwindow/abstract.py
@@ -97,17 +97,17 @@ class AbstractWindow(QtWidgets.QMainWindow):
 
         self.batch = False
 
-        self.maya = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.nuke = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.houdini = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.max = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.fusion = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.blender = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.unreal = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.substancePainter = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.substanceDesigner = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.cryengine = True  #: .. deprecated:: 1.9.0 Use :property:`~BlenderWindow.software` instead.
-        self.standalone = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.maya = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.nuke = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.houdini = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.max = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.fusion = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.blender = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.unreal = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.substancePainter = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.substanceDesigner = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.cryengine = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0
 
         # Read settings
         self._windowDataPath = getWindowSettingsPath(self.WindowID)
@@ -134,8 +134,8 @@ class AbstractWindow(QtWidgets.QMainWindow):
         self.windowReady.connect(lambda: setattr(self, '_windowLoaded', True))
 
     @property
-    def software(self):
-        raise NotImplementedError('`{}.software` property not implemented for the current software.'.format(self.__class__.__name__))
+    def application(self):
+        raise NotImplementedError('`{}.application` property not implemented for the current application.'.format(self.__class__.__name__))
 
     def processEvents(self):
         """Wrapper over the inbult processEvents method.

--- a/vfxwindow/abstract.py
+++ b/vfxwindow/abstract.py
@@ -79,8 +79,6 @@ class AbstractWindow(QtWidgets.QMainWindow):
         setWindowPalette(palette)           # Set a palette
     """
 
-    SOFTWARE = 'Standalone'
-
     clearedInstance = QtCore.Signal()
     windowReady = QtCore.Signal()
 
@@ -120,6 +118,10 @@ class AbstractWindow(QtWidgets.QMainWindow):
         }
 
         self.windowReady.connect(lambda: setattr(self, '_windowLoaded', True))
+
+    @property
+    def software(self):
+        raise NotImplementedError('`{}.software` property not implemented for the current software.'.format(self.__class__.__name__))
 
     def processEvents(self):
         """Wrapper over the inbult processEvents method.

--- a/vfxwindow/abstract.py
+++ b/vfxwindow/abstract.py
@@ -79,6 +79,8 @@ class AbstractWindow(QtWidgets.QMainWindow):
         setWindowPalette(palette)           # Set a palette
     """
 
+    SOFTWARE = 'Standalone'
+
     clearedInstance = QtCore.Signal()
     windowReady = QtCore.Signal()
 
@@ -94,19 +96,6 @@ class AbstractWindow(QtWidgets.QMainWindow):
             self.WindowID = uuid.uuid4()
         self.setWindowTitle(getattr(self, 'WindowName', 'New Window'))
         self._setChildWindow(False)
-
-        # Track settings that to be read by any inherited windows
-        self.batch = False
-        self.maya = False
-        self.nuke = False
-        self.houdini = False
-        self.max = False
-        self.fusion = False
-        self.blender = False
-        self.unreal = False
-        self.substancePainter = False
-        self.substanceDesigner = False
-        self.standalone = False
 
         # Read settings
         self._windowDataPath = getWindowSettingsPath(self.WindowID)

--- a/vfxwindow/abstract.py
+++ b/vfxwindow/abstract.py
@@ -95,6 +95,20 @@ class AbstractWindow(QtWidgets.QMainWindow):
         self.setWindowTitle(getattr(self, 'WindowName', 'New Window'))
         self._setChildWindow(False)
 
+        self.batch = False
+
+        self.maya = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.nuke = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.houdini = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.max = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.fusion = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.blender = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.unreal = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.substancePainter = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.substanceDesigner = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.cryengine = True  #: .. deprecated:: 1.9.0 Use :property:`~BlenderWindow.software` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+
         # Read settings
         self._windowDataPath = getWindowSettingsPath(self.WindowID)
         tempFolder = os.path.dirname(self._windowDataPath)

--- a/vfxwindow/blender.py
+++ b/vfxwindow/blender.py
@@ -20,19 +20,19 @@ class BlenderWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(BlenderWindow, self).__init__(parent, **kwargs)
-        
-        self.blender = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+
+        self.blender = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0
 
     @property
-    def software(self):
+    def application(self):
         return 'Blender'
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -49,10 +49,10 @@ class BlenderWindow(StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
         except KeyError:
             super(BlenderWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/blender.py
+++ b/vfxwindow/blender.py
@@ -20,14 +20,14 @@ class BlenderWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(BlenderWindow, self).__init__(parent, **kwargs)
-        self.blender = True
+        self.software = 'Blender'
         self.standalone = False
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'blender' not in self.windowSettings:
-            self.windowSettings['blender'] = {}
-        settings = self.windowSettings['blender']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -44,10 +44,10 @@ class BlenderWindow(StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings['blender'][key]['x']
-            y = self.windowSettings['blender'][key]['y']
-            width = self.windowSettings['blender'][key]['width']
-            height = self.windowSettings['blender'][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
         except KeyError:
             super(BlenderWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/blender.py
+++ b/vfxwindow/blender.py
@@ -20,7 +20,9 @@ class BlenderWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(BlenderWindow, self).__init__(parent, **kwargs)
-        self.standalone = False
+        
+        self.blender = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
 
     @property
     def software(self):

--- a/vfxwindow/blender.py
+++ b/vfxwindow/blender.py
@@ -20,8 +20,11 @@ class BlenderWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(BlenderWindow, self).__init__(parent, **kwargs)
-        self.software = 'Blender'
         self.standalone = False
+
+    @property
+    def software(self):
+        return 'Blender'
 
     def saveWindowPosition(self):
         """Save the window location."""

--- a/vfxwindow/cryengine.py
+++ b/vfxwindow/cryengine.py
@@ -35,14 +35,14 @@ class CryWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(CryWindow, self).__init__(parent, **kwargs)
-        self.cryengine = True
+        self.software = 'CryEngine'
         self.standalone = False
 
     def saveWindowPosition(self):
         """Save the window location."""
 
-        if 'cryengine' not in self.windowSettings:
-            settings = self.windowSettings['cryengine'] = {}
+        if self.software not in self.windowSettings:
+            settings = self.windowSettings[self.software] = {}
 
         settings['docked'] = self.dockable(raw=True)
 
@@ -66,7 +66,7 @@ class CryWindow(StandaloneWindow):
             return  # Not yet implemented
 
         try:
-            settings = self.windowSettings['cryengine']['main']
+            settings = self.windowSettings[self.software]['main']
             width = settings['width']
             height = settings['height']
             x = settings['x']
@@ -97,7 +97,7 @@ class CryWindow(StandaloneWindow):
             docked = cls.WindowDockable
         else:
             try:
-                docked = settings['cryengine']['docked']
+                docked = settings[self.software]['docked']
             except KeyError:
                 try:
                     docked = cls.WindowDefaults['docked']

--- a/vfxwindow/cryengine.py
+++ b/vfxwindow/cryengine.py
@@ -24,7 +24,6 @@ def getMainWindow():
     """Get a pointer to the CryEngine window.
     This doesn't appear to make any difference to a standalone window.
     """
-
     for widget in QtWidgets.QApplication.topLevelWidgets():
         if type(widget) == QtWidgets.QWidget and widget.parentWidget() is None and widget.objectName() == 'mainWindow':
             return widget
@@ -35,19 +34,18 @@ class CryWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(CryWindow, self).__init__(parent, **kwargs)
-        
-        self.cryengine = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+
+        self.cryengine = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0
 
     @property
-    def software(self):
+    def application(self):
         return 'CryEngine'
 
     def saveWindowPosition(self):
         """Save the window location."""
-
-        if self.software not in self.windowSettings:
-            settings = self.windowSettings[self.software] = {}
+        if self.application not in self.windowSettings:
+            settings = self.windowSettings[self.application] = {}
 
         settings['docked'] = self.dockable(raw=True)
 
@@ -66,12 +64,11 @@ class CryWindow(StandaloneWindow):
 
     def loadWindowPosition(self):
         """Set the position of the window when loaded."""
-
         if self.dockable():
             return  # Not yet implemented
 
         try:
-            settings = self.windowSettings[self.software]['main']
+            settings = self.windowSettings[self.application]['main']
             width = settings['width']
             height = settings['height']
             x = settings['x']
@@ -102,7 +99,7 @@ class CryWindow(StandaloneWindow):
             docked = cls.WindowDockable
         else:
             try:
-                docked = settings[self.software]['docked']
+                docked = settings[self.application]['docked']
             except KeyError:
                 try:
                     docked = cls.WindowDefaults['docked']

--- a/vfxwindow/cryengine.py
+++ b/vfxwindow/cryengine.py
@@ -35,8 +35,11 @@ class CryWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(CryWindow, self).__init__(parent, **kwargs)
-        self.software = 'CryEngine'
         self.standalone = False
+
+    @property
+    def software(self):
+        return 'CryEngine'
 
     def saveWindowPosition(self):
         """Save the window location."""

--- a/vfxwindow/cryengine.py
+++ b/vfxwindow/cryengine.py
@@ -35,7 +35,9 @@ class CryWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(CryWindow, self).__init__(parent, **kwargs)
-        self.standalone = False
+        
+        self.cryengine = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
 
     @property
     def software(self):

--- a/vfxwindow/debug.py
+++ b/vfxwindow/debug.py
@@ -10,6 +10,7 @@ class TestWindow(VFXWindow):
     def __init__(self, **kwargs):
         self._signalPause = False
         super(TestWindow, self).__init__(**kwargs)
+        self.setWindowIcon(self.style().standardIcon(QtWidgets.QStyle.SP_DirIcon))
 
         widget = QtWidgets.QWidget()
         self.setCentralWidget(widget)

--- a/vfxwindow/fusion.py
+++ b/vfxwindow/fusion.py
@@ -36,7 +36,9 @@ class FusionWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(FusionWindow, self).__init__(parent, **kwargs)
-        self.standalone = False
+        
+        self.fusion = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
 
     @property
     def software(self):

--- a/vfxwindow/fusion.py
+++ b/vfxwindow/fusion.py
@@ -9,8 +9,8 @@ try:
     import fusionscript
     fusion = fusionscript.scriptapp('Fusion')
 except ImportError:
-    import PeyeonScript as eyeon
-    fusion = eyeon.scriptapp('Fusion')
+    import PeyeonScript
+    fusion = PeyeonScript.scriptapp('Fusion')
 
 from .utils import setCoordinatesToScreen, hybridmethod
 from .standalone import StandaloneWindow
@@ -36,14 +36,14 @@ class FusionWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(FusionWindow, self).__init__(parent, **kwargs)
-        self.fusion = True
+        self.software = 'Fusion'
         self.standalone = False
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'fusion' not in self.windowSettings:
-            self.windowSettings['fusion'] = {}
-        settings = self.windowSettings['fusion']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -60,10 +60,10 @@ class FusionWindow(StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings['fusion'][key]['width']
-            height = self.windowSettings['fusion'][key]['height']
-            x = self.windowSettings['fusion'][key]['x']
-            y = self.windowSettings['fusion'][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
         except KeyError:
             super(FusionWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/fusion.py
+++ b/vfxwindow/fusion.py
@@ -36,8 +36,11 @@ class FusionWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(FusionWindow, self).__init__(parent, **kwargs)
-        self.software = 'Fusion'
         self.standalone = False
+
+    @property
+    def software(self):
+        return 'Fusion'
 
     def saveWindowPosition(self):
         """Save the window location."""

--- a/vfxwindow/fusion.py
+++ b/vfxwindow/fusion.py
@@ -36,19 +36,19 @@ class FusionWindow(StandaloneWindow):
         if parent is None:
             parent = getMainWindow()
         super(FusionWindow, self).__init__(parent, **kwargs)
-        
-        self.fusion = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+
+        self.fusion = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0
 
     @property
-    def software(self):
+    def application(self):
         return 'Fusion'
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -65,10 +65,10 @@ class FusionWindow(StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
         except KeyError:
             super(FusionWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/houdini.py
+++ b/vfxwindow/houdini.py
@@ -35,6 +35,8 @@ class HoudiniWindow(AbstractWindow):
             parent = getMainWindow()
         super(HoudiniWindow, self).__init__(parent, **kwargs)
 
+        self.houdini = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+
         # Fix some issues with widgets not taking the correct style
         self.setStyleSheet("""
             QScrollArea{

--- a/vfxwindow/houdini.py
+++ b/vfxwindow/houdini.py
@@ -34,7 +34,7 @@ class HoudiniWindow(AbstractWindow):
         if parent is None:
             parent = getMainWindow()
         super(HoudiniWindow, self).__init__(parent, **kwargs)
-        self.houdini = True
+        self.software = 'Houdini'
 
         # Fix some issues with widgets not taking the correct style
         self.setStyleSheet("""
@@ -73,9 +73,9 @@ class HoudiniWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'houdini' not in self.windowSettings:
-            self.windowSettings['houdini'] = {}
-        settings = self.windowSettings['houdini']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -92,10 +92,10 @@ class HoudiniWindow(AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings['houdini'][key]['x']
-            y = self.windowSettings['houdini'][key]['y']
-            width = self.windowSettings['houdini'][key]['width']
-            height = self.windowSettings['houdini'][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
         except KeyError:
             super(HoudiniWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/houdini.py
+++ b/vfxwindow/houdini.py
@@ -35,7 +35,7 @@ class HoudiniWindow(AbstractWindow):
             parent = getMainWindow()
         super(HoudiniWindow, self).__init__(parent, **kwargs)
 
-        self.houdini = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.houdini = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
 
         # Fix some issues with widgets not taking the correct style
         self.setStyleSheet("""
@@ -57,7 +57,7 @@ class HoudiniWindow(AbstractWindow):
         self.setWindowFlags(self.windowFlags() | QtCore.Qt.Dialog)
 
     @property
-    def software(self):
+    def application(self):
         return 'Houdini'
 
     def closeEvent(self, event):
@@ -78,9 +78,9 @@ class HoudiniWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -97,10 +97,10 @@ class HoudiniWindow(AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
         except KeyError:
             super(HoudiniWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/houdini.py
+++ b/vfxwindow/houdini.py
@@ -34,7 +34,6 @@ class HoudiniWindow(AbstractWindow):
         if parent is None:
             parent = getMainWindow()
         super(HoudiniWindow, self).__init__(parent, **kwargs)
-        self.software = 'Houdini'
 
         # Fix some issues with widgets not taking the correct style
         self.setStyleSheet("""
@@ -54,6 +53,10 @@ class HoudiniWindow(AbstractWindow):
 
         # As of today, that's the only solution that seems to make this window stay over houdini.
         self.setWindowFlags(self.windowFlags() | QtCore.Qt.Dialog)
+
+    @property
+    def software(self):
+        return 'Houdini'
 
     def closeEvent(self, event):
         """Save the window location on window close."""

--- a/vfxwindow/max.py
+++ b/vfxwindow/max.py
@@ -35,7 +35,10 @@ class MaxWindow(AbstractWindow):
         if parent is None:
             parent = getMainWindow()
         super(MaxWindow, self).__init__(parent, **kwargs)
-        self.software = '3DsMax'
+
+    @property
+    def software(self):
+        return '3DsMax'
 
     def saveWindowPosition(self):
         """Save the window location."""

--- a/vfxwindow/max.py
+++ b/vfxwindow/max.py
@@ -35,13 +35,13 @@ class MaxWindow(AbstractWindow):
         if parent is None:
             parent = getMainWindow()
         super(MaxWindow, self).__init__(parent, **kwargs)
-        self.max = True
+        self.software = '3DsMax'
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'max' not in self.windowSettings:
-            self.windowSettings['max'] = {}
-        settings = self.windowSettings['max']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -58,10 +58,10 @@ class MaxWindow(AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings['max'][key]['width']
-            height = self.windowSettings['max'][key]['height']
-            x = self.windowSettings['max'][key]['x']
-            y = self.windowSettings['max'][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
         except KeyError:
             super(MaxWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/max.py
+++ b/vfxwindow/max.py
@@ -36,17 +36,17 @@ class MaxWindow(AbstractWindow):
             parent = getMainWindow()
         super(MaxWindow, self).__init__(parent, **kwargs)
 
-        self.max = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.max = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
 
     @property
-    def software(self):
+    def application(self):
         return '3dsMax'
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -63,10 +63,10 @@ class MaxWindow(AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
         except KeyError:
             super(MaxWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/max.py
+++ b/vfxwindow/max.py
@@ -38,7 +38,7 @@ class MaxWindow(AbstractWindow):
 
     @property
     def software(self):
-        return '3DsMax'
+        return '3dsMax'
 
     def saveWindowPosition(self):
         """Save the window location."""

--- a/vfxwindow/max.py
+++ b/vfxwindow/max.py
@@ -36,6 +36,8 @@ class MaxWindow(AbstractWindow):
             parent = getMainWindow()
         super(MaxWindow, self).__init__(parent, **kwargs)
 
+        self.max = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+
     @property
     def software(self):
         return '3dsMax'

--- a/vfxwindow/maya.py
+++ b/vfxwindow/maya.py
@@ -51,7 +51,7 @@ def getMainWindow(windowID=None, wrapInstance=True):
             pointer = omUI.MQtUtil.findControl(windowID)
         else:
             pointer = omUI.MQtUtil.mainWindow()
-        
+
         if pointer is not None:
             return QtCompat.wrapInstance(int(pointer), QtWidgets.QWidget)
 
@@ -371,16 +371,16 @@ class MayaWindow(MayaCommon, AbstractWindow):
             base = self.parent()
 
         if base is None:
-            # If the window has no parent, it was probably forgotten by user so we can 
+            # If the window has no parent, it was probably forgotten by user so we can
             # assume it should be the maya main window.
-            self.__parentTemp = getMainWindow()
+            self.__parentTemp = super(MayaWindow, self)._parentOverride()
         else:
             #Get the correct parent level
             if self.floating():
                 self.__parentTemp = base.parent().parent().parent().parent()
             else:
                 self.__parentTemp = base.parent().parent()
-        
+
         return self.__parentTemp
 
     def floating(self):

--- a/vfxwindow/maya.py
+++ b/vfxwindow/maya.py
@@ -217,7 +217,9 @@ def toMObject(node):
 
 class MayaCommon(object):
 
-    SOFTWARE = 'Maya'
+    @property
+    def software(self):
+        return 'Maya'
 
     def deferred(self, func, *args, **kwargs):
         """Execute a deferred command.
@@ -480,9 +482,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.SOFTWARE not in self.windowSettings:
-            self.windowSettings[self.SOFTWARE] = {}
-        settings = self.windowSettings[self.SOFTWARE]
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
         settings['docked'] = self.dockable(raw=True)
 
         key = self._getSettingsKey()
@@ -519,10 +521,10 @@ class MayaWindow(MayaCommon, AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings[self.SOFTWARE][key]['x']
-            y = self.windowSettings[self.SOFTWARE][key]['y']
-            width = self.windowSettings[self.SOFTWARE][key]['width']
-            height = self.windowSettings[self.SOFTWARE][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
         except KeyError:
             super(MayaWindow, self).loadWindowPosition()
         else:
@@ -898,15 +900,15 @@ class MayaWindow(MayaCommon, AbstractWindow):
 
         # Load settings
         try:
-            mayaSettings = settings[self.SOFTWARE]
+            mayaSettings = settings[self.software]
         except KeyError:
-            mayaSettings = settings[self.SOFTWARE] = {}
+            mayaSettings = settings[self.software] = {}
 
         if hasattr(cls, 'WindowDockable'):
             docked = cls.WindowDockable
         else:
             try:
-                docked = settings[self.SOFTWARE]['docked']
+                docked = settings[self.software]['docked']
             except KeyError:
                 try:
                     docked = cls.WindowDefaults['docked']
@@ -925,7 +927,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
                 floating = not cls.WindowDocked
             else:
                 try:
-                    floating = settings[self.SOFTWARE]['dock']['floating']
+                    floating = settings[self.software]['dock']['floating']
                 except KeyError:
                     try:
                         floating = cls.WindowDefaults['floating']
@@ -936,9 +938,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
             else:
                 try:
                     if self._Pre2017:
-                        dock = settings[self.SOFTWARE]['dock'].get('area', True)
+                        dock = settings[self.software]['dock'].get('area', True)
                     else:
-                        dock = settings[self.SOFTWARE]['dock'].get('control', True)
+                        dock = settings[self.software]['dock'].get('control', True)
                 except KeyError:
                     dock = True
             if self._Pre2017:
@@ -1003,9 +1005,9 @@ class MayaBatchWindow(MayaCommon, StandaloneWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.SOFTWARE not in self.windowSettings:
-            self.windowSettings[self.SOFTWARE] = {}
-        settings = self.windowSettings[self.SOFTWARE]
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -1022,10 +1024,10 @@ class MayaBatchWindow(MayaCommon, StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.SOFTWARE][key]['width']
-            height = self.windowSettings[self.SOFTWARE][key]['height']
-            x = self.windowSettings[self.SOFTWARE][key]['x']
-            y = self.windowSettings[self.SOFTWARE][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
         except KeyError:
             super(MayaBatchWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/maya.py
+++ b/vfxwindow/maya.py
@@ -10,7 +10,6 @@ import maya.mel as mel
 import maya.cmds as mc
 import maya.api.OpenMaya as om
 import maya.OpenMayaUI as omUI
-import pymel.core as pm
 
 from .abstract import AbstractWindow, getWindowSettings
 from .standalone import StandaloneWindow
@@ -49,16 +48,10 @@ def getMainWindow(windowID=None, wrapInstance=True):
     """
     if wrapInstance:
         if windowID is not None:
-            # ID is possibly a Maya widget
-            if '|' in str(windowID):
-                qtObj = pm.uitypes.toQtObject(windowID)
-                if qtObj is not None:
-                    return qtObj
-
-            # ID is an existing window
             pointer = omUI.MQtUtil.findControl(windowID)
         else:
             pointer = omUI.MQtUtil.mainWindow()
+        
         if pointer is not None:
             return QtCompat.wrapInstance(int(pointer), QtWidgets.QWidget)
 
@@ -73,15 +66,15 @@ def getMainWindow(windowID=None, wrapInstance=True):
 
 def deleteWorkspaceControl(windowID, resetFloating=True):
     """Handle deleting a workspaceControl with a particular ID."""
-    if pm.workspaceControl(windowID, query=True, exists=True):
-        floating = pm.workspaceControl(windowID, query=True, floating=True)
-        pm.deleteUI(windowID)
+    if mc.workspaceControl(windowID, query=True, exists=True):
+        floating = mc.workspaceControl(windowID, query=True, floating=True)
+        mc.deleteUI(windowID)
     else:
         floating = None
 
     #Delete the window preferences (position, size, etc), if the window is not currently floating
-    if pm.workspaceControlState(windowID, query=True, exists=True) and (not floating or floating and resetFloating):
-        pm.workspaceControlState(windowID, remove=True)
+    if mc.workspaceControlState(windowID, query=True, exists=True) and (not floating or floating and resetFloating):
+        mc.workspaceControlState(windowID, remove=True)
 
     return floating
 
@@ -89,10 +82,10 @@ def deleteWorkspaceControl(windowID, resetFloating=True):
 def deleteDockControl(windowID):
     """Handle deleting a dockControl with a particular ID."""
     # Get current floating state
-    if pm.dockControl(windowID, query=True, exists=True):
-        floating = pm.dockControl(windowID, query=True, floating=True)
-        pm.dockControl(windowID, edit=True, r=True)
-        pm.dockControl(windowID, edit=True, floating=False)
+    if mc.dockControl(windowID, query=True, exists=True):
+        floating = mc.dockControl(windowID, query=True, floating=True)
+        mc.dockControl(windowID, edit=True, r=True)
+        mc.dockControl(windowID, edit=True, floating=False)
     else:
         floating = None
 
@@ -104,7 +97,7 @@ def deleteDockControl(windowID):
 
     if floating is not None:
         try:
-            pm.dockControl(windowID, edit=True, floating=floating)
+            mc.dockControl(windowID, edit=True, floating=floating)
         except RuntimeError:
             pass
 
@@ -135,12 +128,12 @@ def workspaceControlWrap(windowClass, dock=True, resetFloating=True, *args, **kw
         if isinstance(dock, (bool, int)):
             dock = defaultDock
         try:
-            pm.workspaceControl(WindowClass.WindowID, retain=True, label=getattr(WindowClass, 'WindowName', 'New Window'), tabToControl=[dock, -1])
+            mc.workspaceControl(WindowClass.WindowID, retain=True, label=getattr(WindowClass, 'WindowName', 'New Window'), tabToControl=[dock, -1])
         except RuntimeError:
             deleteWorkspaceControl(WindowClass.WindowID, resetFloating=resetFloating)
-            pm.workspaceControl(WindowClass.WindowID, retain=True, label=getattr(WindowClass, 'WindowName', 'New Window'), tabToControl=[defaultDock, -1])
+            mc.workspaceControl(WindowClass.WindowID, retain=True, label=getattr(WindowClass, 'WindowName', 'New Window'), tabToControl=[defaultDock, -1])
     else:
-        pm.workspaceControl(WindowClass.WindowID, retain=True, label=getattr(WindowClass, 'WindowName', 'New Window'), floating=True)
+        mc.workspaceControl(WindowClass.WindowID, retain=True, label=getattr(WindowClass, 'WindowName', 'New Window'), floating=True)
 
     # Setup main window and parent to Maya
     workspaceControlWin = getMainWindow(WindowClass.WindowID)
@@ -151,7 +144,7 @@ def workspaceControlWrap(windowClass, dock=True, resetFloating=True, *args, **kw
     # Attach callbacks
     windowInstance.signalConnect(workspaceControlWin.destroyed, windowInstance.close, group='__mayaDockWinDestroy')
     try:
-        pm.workspaceControl(WindowClass.WindowID, edit=True, visibleChangeCommand=windowInstance.visibleChangeEvent)
+        mc.workspaceControl(WindowClass.WindowID, edit=True, visibleChangeCommand=windowInstance.visibleChangeEvent)
     except (AttributeError, TypeError):
         pass
     try:
@@ -173,11 +166,11 @@ def dockControlWrap(windowClass, dock=True, *args, **kwargs):
             dock = 'right'
         if not windowInstance.objectName():
             windowInstance.setObjectName(windowInstance.WindowID)
-        pm.dockControl(windowInstance.WindowID, area=dock, floating=False, retain=False, content=windowInstance.objectName(), closeCommand=windowInstance.close)
+        mc.dockControl(windowInstance.WindowID, area=dock, floating=False, retain=False, content=windowInstance.objectName(), closeCommand=windowInstance.close)
 
         windowInstance.setDocked(dock)
         try:
-            pm.dockControl(windowInstance.WindowID, edit=True, floatChangeCommand=windowInstance.saveWindowPosition)
+            mc.dockControl(windowInstance.WindowID, edit=True, floatChangeCommand=windowInstance.saveWindowPosition)
         except (AttributeError, TypeError):
             pass
 
@@ -223,6 +216,9 @@ def toMObject(node):
 
 
 class MayaCommon(object):
+
+    SOFTWARE = 'Maya'
+
     def deferred(self, func, *args, **kwargs):
         """Execute a deferred command.
         If the window is a dialog, then execute now as Maya will pause.
@@ -230,7 +226,7 @@ class MayaCommon(object):
         if self.isDialog():
             return func()
         else:
-            pm.evalDeferred(func, *args, **kwargs)
+            mc.evalDeferred(func, *args, **kwargs)
 
 
 class MayaWindow(MayaCommon, AbstractWindow):
@@ -246,7 +242,6 @@ class MayaWindow(MayaCommon, AbstractWindow):
         if parent is None:
             parent = getMainWindow()
         super(MayaWindow, self).__init__(parent, **kwargs)
-        self.maya = True
         self.batch = BATCH
         self.setDockable(dockable, override=True)
 
@@ -265,7 +260,11 @@ class MayaWindow(MayaCommon, AbstractWindow):
             # Maya set it's own window icon to this widget by default, this will just make sure that if the user
             # used a custom icon for it's tool, it's set on the dynamically created floating widget.
             if self.floating():
-                self._parentOverride().setWindowIcon(self.windowIcon())
+                self.setWindowIcon(self.windowIcon())
+
+    def setWindowIcon(self, icon):
+        super(MayaWindow, self).setWindowIcon(icon)
+        self._parentOverride().setWindowIcon(icon)
 
     def closeEvent(self, event):
         """Handle the class being deleted."""
@@ -289,23 +288,23 @@ class MayaWindow(MayaCommon, AbstractWindow):
     def exists(self):
         if self.dockable():
             if self._Pre2017:
-                return pm.dockControl(self.WindowID, query=True, exists=True)
-            return pm.workspaceControl(self.WindowID, query=True, exists=True)
+                return mc.dockControl(self.WindowID, query=True, exists=True)
+            return mc.workspaceControl(self.WindowID, query=True, exists=True)
         return not self.isClosed()
 
     def raise_(self):
         if self.dockable():
             if self._Pre2017:
-                return pm.dockControl(self.WindowID, edit=True, r=True)
-            return pm.workspaceControl(self.WindowID, edit=True, restore=True)
+                return mc.dockControl(self.WindowID, edit=True, r=True)
+            return mc.workspaceControl(self.WindowID, edit=True, restore=True)
         return super(MayaWindow, self).raise_()
 
     def setWindowTitle(self, title):
         if self.dockable():
             try:
                 if self._Pre2017:
-                    return pm.dockControl(self.WindowID, edit=True, label=title)
-                return pm.workspaceControl(self.WindowID, edit=True, label=title)
+                    return mc.dockControl(self.WindowID, edit=True, label=title)
+                return mc.workspaceControl(self.WindowID, edit=True, label=title)
             except RuntimeError:
                 pass
         return super(MayaWindow, self).setWindowTitle(title)
@@ -314,8 +313,8 @@ class MayaWindow(MayaCommon, AbstractWindow):
         if self.dockable():
             try:
                 if self._Pre2017:
-                    return pm.dockControl(self.WindowID, query=True, visible=True)
-                return pm.workspaceControl(self.WindowID, query=True, visible=True)
+                    return mc.dockControl(self.WindowID, query=True, visible=True)
+                return mc.workspaceControl(self.WindowID, query=True, visible=True)
             except RuntimeError:
                 return False
         return super(MayaWindow, self).isVisible()
@@ -333,10 +332,10 @@ class MayaWindow(MayaCommon, AbstractWindow):
         if self.dockable() and self.floating() == dock:
             if self._Pre2017:
                 self.raise_()
-                pm.dockControl(self.WindowID, edit=True, floating=not dock)
+                mc.dockControl(self.WindowID, edit=True, floating=not dock)
                 self.raise_()
             else:
-                pm.workspaceControl(self.WindowID, edit=True, floating=not dock)
+                mc.workspaceControl(self.WindowID, edit=True, floating=not dock)
 
     def setWindowPalette(self, program, version=None, style=True, force=False):
         """Set the palette of the window.
@@ -366,11 +365,17 @@ class MayaWindow(MayaCommon, AbstractWindow):
         else:
             base = self.parent()
 
-        #Get the correct parent level
-        if self.floating():
-            self.__parentTemp = base.parent().parent().parent().parent()
+        if base is None:
+            # If the window has no parent, it was probably forgotten by user so we can 
+            # assume it should be the maya main window.
+            self.__parentTemp = getMainWindow()
         else:
-            self.__parentTemp = base.parent().parent()
+            #Get the correct parent level
+            if self.floating():
+                self.__parentTemp = base.parent().parent().parent().parent()
+            else:
+                self.__parentTemp = base.parent().parent()
+        
         return self.__parentTemp
 
     def floating(self):
@@ -378,8 +383,8 @@ class MayaWindow(MayaCommon, AbstractWindow):
         if not self.dockable():
             return False
         if self._Pre2017:
-            return pm.dockControl(self.WindowID, query=True, floating=True)
-        return pm.workspaceControl(self.WindowID, query=True, floating=True)
+            return mc.dockControl(self.WindowID, query=True, floating=True)
+        return mc.workspaceControl(self.WindowID, query=True, floating=True)
 
     def resize(self, width, height=None):
         """Resize the window."""
@@ -389,9 +394,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
         if self.dockable():
             if self._Pre2017:
                 if not self.floating():
-                    return pm.dockControl(self.WindowID, edit=True, width=width, height=height)
+                    return mc.dockControl(self.WindowID, edit=True, width=width, height=height)
             else:
-                return pm.workspaceControl(self.WindowID, edit=True, resizeWidth=width, resizeHeight=height)
+                return mc.workspaceControl(self.WindowID, edit=True, resizeWidth=width, resizeHeight=height)
         return super(MayaWindow, self).resize(width, height)
 
     def siblings(self):
@@ -405,7 +410,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
     if _Pre2017:
         def area(self, *args, **kwargs):
             """Return the Maya area name."""
-            return pm.dockControl(self.WindowID, query=True, area=True)
+            return mc.dockControl(self.WindowID, query=True, area=True)
 
     else:
         def control(self, *args, **kwargs):
@@ -445,7 +450,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
             ]
             stackedWidget = self.parent().parent()
             for control in workspaces:
-                widget = pm.uitypes.toQtControl(control)
+                widget = getMainWindow(control)
                 if widget is not None:
                     if widget.parent() is stackedWidget:
                         return control
@@ -475,9 +480,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'maya' not in self.windowSettings:
-            self.windowSettings['maya'] = {}
-        settings = self.windowSettings['maya']
+        if self.SOFTWARE not in self.windowSettings:
+            self.windowSettings[self.SOFTWARE] = {}
+        settings = self.windowSettings[self.SOFTWARE]
         settings['docked'] = self.dockable(raw=True)
 
         key = self._getSettingsKey()
@@ -514,10 +519,10 @@ class MayaWindow(MayaCommon, AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings['maya'][key]['x']
-            y = self.windowSettings['maya'][key]['y']
-            width = self.windowSettings['maya'][key]['width']
-            height = self.windowSettings['maya'][key]['height']
+            x = self.windowSettings[self.SOFTWARE][key]['x']
+            y = self.windowSettings[self.SOFTWARE][key]['y']
+            width = self.windowSettings[self.SOFTWARE][key]['width']
+            height = self.windowSettings[self.SOFTWARE][key]['height']
         except KeyError:
             super(MayaWindow, self).loadWindowPosition()
         else:
@@ -528,7 +533,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
     def displayMessage(self, title, message, details=None, buttons=('Ok',), defaultButton=None, cancelButton=None, checkBox=None):
         """This is basically Maya's copy of a QMessageBox."""
         if checkBox is None:
-            return pm.confirmDialog(
+            return mc.confirmDialog(
                 title=title,
                 message=message,
                 button=buttons,
@@ -611,7 +616,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
                     numEvents += 1
             for callbackID in windowInstance['callback'][group]['job']:
                 try:
-                    pm.scriptJob(kill=callbackID)
+                    mc.scriptJob(kill=callbackID)
                 except RuntimeError:
                     pass
                 else:
@@ -784,11 +789,11 @@ class MayaWindow(MayaCommon, AbstractWindow):
 
     def addCallbackJobEvent(self, callback, func, group=None, runOnce=False):
         self._addMayaCallbackGroup(group)
-        self.windowInstance()['callback'][group]['job'].append(pm.scriptJob(runOnce=runOnce, event=[callback, func]))
+        self.windowInstance()['callback'][group]['job'].append(mc.scriptJob(runOnce=runOnce, event=[callback, func]))
 
     def addCallbackJobCondition(self, callback, func, group=None, runOnce=False):
         self._addMayaCallbackGroup(group)
-        self.windowInstance()['callback'][group]['job'].append(pm.scriptJob(runOnce=runOnce, conditionChange=[callback, func]))
+        self.windowInstance()['callback'][group]['job'].append(mc.scriptJob(runOnce=runOnce, conditionChange=[callback, func]))
 
     def addCallbackNodeTypeAdd(self, func, nodeType='dependNode', clientData=None, group=None):
         """Add an MDGMessage callback for whenever a new node is added to the dependency graph."""
@@ -855,16 +860,16 @@ class MayaWindow(MayaCommon, AbstractWindow):
     def setFocus(self):
         """Force Maya to focus on the window."""
         if self.dockable():
-            return pm.setFocus(self.WindowID)
+            return mc.setFocus(self.WindowID)
         return super(MayaWindow, self).setFocus()
 
     def hide(self):
         """Hide the window."""
         if self.dockable():
             if self._Pre2017:
-                return pm.dockControl(self.WindowID, edit=True, visible=False)
+                return mc.dockControl(self.WindowID, edit=True, visible=False)
             self.parent().setAttribute(QtCore.Qt.WA_DeleteOnClose, False)
-            return pm.workspaceControl(self.WindowID, edit=True, visible=False)
+            return mc.workspaceControl(self.WindowID, edit=True, visible=False)
         return super(MayaWindow, self).hide()
 
     @hybridmethod
@@ -876,8 +881,8 @@ class MayaWindow(MayaCommon, AbstractWindow):
             # Case where window is already initialised
             if self.dockable():
                 if self._Pre2017:
-                    return pm.dockControl(self.WindowID, edit=True, visible=True)
-                result = pm.workspaceControl(self.WindowID, edit=True, visible=True)
+                    return mc.dockControl(self.WindowID, edit=True, visible=True)
+                result = mc.workspaceControl(self.WindowID, edit=True, visible=True)
                 self.parent().setAttribute(QtCore.Qt.WA_DeleteOnClose)
                 return result
             return super(MayaWindow, self).show()
@@ -893,15 +898,15 @@ class MayaWindow(MayaCommon, AbstractWindow):
 
         # Load settings
         try:
-            mayaSettings = settings['maya']
+            mayaSettings = settings[self.SOFTWARE]
         except KeyError:
-            mayaSettings = settings['maya'] = {}
+            mayaSettings = settings[self.SOFTWARE] = {}
 
         if hasattr(cls, 'WindowDockable'):
             docked = cls.WindowDockable
         else:
             try:
-                docked = settings['maya']['docked']
+                docked = settings[self.SOFTWARE]['docked']
             except KeyError:
                 try:
                     docked = cls.WindowDefaults['docked']
@@ -920,7 +925,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
                 floating = not cls.WindowDocked
             else:
                 try:
-                    floating = settings['maya']['dock']['floating']
+                    floating = settings[self.SOFTWARE]['dock']['floating']
                 except KeyError:
                     try:
                         floating = cls.WindowDefaults['floating']
@@ -931,9 +936,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
             else:
                 try:
                     if self._Pre2017:
-                        dock = settings['maya']['dock'].get('area', True)
+                        dock = settings[self.SOFTWARE]['dock'].get('area', True)
                     else:
-                        dock = settings['maya']['dock'].get('control', True)
+                        dock = settings[self.SOFTWARE]['dock'].get('control', True)
                 except KeyError:
                     dock = True
             if self._Pre2017:
@@ -949,15 +954,15 @@ class MayaWindow(MayaCommon, AbstractWindow):
     @classmethod
     def dialog(cls, parent=None, *args, **kwargs):
         """Create the window as a dialog.
-        For Maya versions after 2017, pm.layoutDialog is used.
+        For Maya versions after 2017, mc.layoutDialog is used.
         """
         # This is quite buggy and can lock up Maya, so disable for now
         if False and not cls._Pre2017:
             # Note: Due to Python 2 limitations, *args and **kwargs can't be unpacked with the
             # title keyword present, so don't try to clean up the code by enabling unpacking again.
             def uiScript(cls, clsArgs=(), clsKwargs={}):
-                form = pm.setParent(query=True)
-                parent = pm.uitypes.toQtObject(form)
+                form = mc.setParent(query=True)
+                parent = mc.uitypes.toQtObject(form)
                 parent.layout().setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
 
                 windowInstance = cls(parent, *clsArgs, **clsKwargs)
@@ -974,7 +979,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
                         return super(WindowClass, self).enableSaveWindowPosition(False)
 
             try:
-                return pm.layoutDialog(
+                return mc.layoutDialog(
                     ui=partial(uiScript, WindowClass, clsArgs=args, clsKwargs=kwargs),
                     title=getattr(cls, 'WindowTitle', 'New Window'),
                 )
@@ -993,15 +998,14 @@ class MayaBatchWindow(MayaCommon, StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(MayaBatchWindow, self).__init__(parent, **kwargs)
-        self.maya = True
         self.batch = True
         self.standalone = False
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'maya' not in self.windowSettings:
-            self.windowSettings['maya'] = {}
-        settings = self.windowSettings['maya']
+        if self.SOFTWARE not in self.windowSettings:
+            self.windowSettings[self.SOFTWARE] = {}
+        settings = self.windowSettings[self.SOFTWARE]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -1018,10 +1022,10 @@ class MayaBatchWindow(MayaCommon, StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings['maya'][key]['width']
-            height = self.windowSettings['maya'][key]['height']
-            x = self.windowSettings['maya'][key]['x']
-            y = self.windowSettings['maya'][key]['y']
+            width = self.windowSettings[self.SOFTWARE][key]['width']
+            height = self.windowSettings[self.SOFTWARE][key]['height']
+            x = self.windowSettings[self.SOFTWARE][key]['x']
+            y = self.windowSettings[self.SOFTWARE][key]['y']
         except KeyError:
             super(MayaBatchWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/maya.py
+++ b/vfxwindow/maya.py
@@ -244,6 +244,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
         if parent is None:
             parent = getMainWindow()
         super(MayaWindow, self).__init__(parent, **kwargs)
+
+        self.maya = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+
         self.batch = BATCH
         self.setDockable(dockable, override=True)
 
@@ -1000,8 +1003,11 @@ class MayaBatchWindow(MayaCommon, StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(MayaBatchWindow, self).__init__(parent, **kwargs)
+
+        self.maya = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+
         self.batch = True
-        self.standalone = False
 
     def saveWindowPosition(self):
         """Save the window location."""

--- a/vfxwindow/maya.py
+++ b/vfxwindow/maya.py
@@ -962,12 +962,13 @@ class MayaWindow(MayaCommon, AbstractWindow):
         For Maya versions after 2017, mc.layoutDialog is used.
         """
         # This is quite buggy and can lock up Maya, so disable for now
+        # The issue is likely related to what `setParent` returns.
         if False and not cls._Pre2017:
             # Note: Due to Python 2 limitations, *args and **kwargs can't be unpacked with the
             # title keyword present, so don't try to clean up the code by enabling unpacking again.
             def uiScript(cls, clsArgs=(), clsKwargs={}):
                 form = mc.setParent(query=True)
-                parent = mc.uitypes.toQtObject(form)
+                parent = getMainWindow(form)
                 parent.layout().setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
 
                 windowInstance = cls(parent, *clsArgs, **clsKwargs)

--- a/vfxwindow/maya.py
+++ b/vfxwindow/maya.py
@@ -218,7 +218,7 @@ def toMObject(node):
 class MayaCommon(object):
 
     @property
-    def software(self):
+    def application(self):
         return 'Maya'
 
     def deferred(self, func, *args, **kwargs):
@@ -245,7 +245,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
             parent = getMainWindow()
         super(MayaWindow, self).__init__(parent, **kwargs)
 
-        self.maya = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.maya = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
 
         self.batch = BATCH
         self.setDockable(dockable, override=True)
@@ -485,9 +485,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
         settings['docked'] = self.dockable(raw=True)
 
         key = self._getSettingsKey()
@@ -524,10 +524,10 @@ class MayaWindow(MayaCommon, AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
         except KeyError:
             super(MayaWindow, self).loadWindowPosition()
         else:
@@ -903,15 +903,15 @@ class MayaWindow(MayaCommon, AbstractWindow):
 
         # Load settings
         try:
-            mayaSettings = settings[self.software]
+            mayaSettings = settings[self.application]
         except KeyError:
-            mayaSettings = settings[self.software] = {}
+            mayaSettings = settings[self.application] = {}
 
         if hasattr(cls, 'WindowDockable'):
             docked = cls.WindowDockable
         else:
             try:
-                docked = settings[self.software]['docked']
+                docked = settings[self.application]['docked']
             except KeyError:
                 try:
                     docked = cls.WindowDefaults['docked']
@@ -930,7 +930,7 @@ class MayaWindow(MayaCommon, AbstractWindow):
                 floating = not cls.WindowDocked
             else:
                 try:
-                    floating = settings[self.software]['dock']['floating']
+                    floating = settings[self.application]['dock']['floating']
                 except KeyError:
                     try:
                         floating = cls.WindowDefaults['floating']
@@ -941,9 +941,9 @@ class MayaWindow(MayaCommon, AbstractWindow):
             else:
                 try:
                     if self._Pre2017:
-                        dock = settings[self.software]['dock'].get('area', True)
+                        dock = settings[self.application]['dock'].get('area', True)
                     else:
-                        dock = settings[self.software]['dock'].get('control', True)
+                        dock = settings[self.application]['dock'].get('control', True)
                 except KeyError:
                     dock = True
             if self._Pre2017:
@@ -1005,16 +1005,16 @@ class MayaBatchWindow(MayaCommon, StandaloneWindow):
     def __init__(self, parent=None, **kwargs):
         super(MayaBatchWindow, self).__init__(parent, **kwargs)
 
-        self.maya = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+        self.maya = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0
 
         self.batch = True
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -1031,10 +1031,10 @@ class MayaBatchWindow(MayaCommon, StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
         except KeyError:
             super(MayaBatchWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/nuke.py
+++ b/vfxwindow/nuke.py
@@ -278,6 +278,8 @@ class NukeWindow(NukeCommon, AbstractWindow):
             parent = getMainWindow()
         super(NukeWindow, self).__init__(parent, **kwargs)
 
+        self.nuke = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.    
+
         self.__windowHidden = False
         self.setDockable(dockable, override=True)
 
@@ -827,8 +829,11 @@ class NukeBatchWindow(NukeCommon, StandaloneWindow):
     """Variant of the Standalone window for Nuke in batch mode."""
     def __init__(self, parent=None, **kwargs):
         super(NukeBatchWindow, self).__init__(parent, **kwargs)
+
+        self.nuke = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+
         self.batch = True
-        self.standalone = False
 
     def setWindowPalette(self, program, version=None, style=True, force=False):
         if force:

--- a/vfxwindow/nuke.py
+++ b/vfxwindow/nuke.py
@@ -227,7 +227,9 @@ class Pane(object):
 
 
 class NukeCommon(object):
-    pass
+    def __init__(self, *args, **kwargs):
+        super(NukeCommon, self).__init__(*args, **kwargs)
+        self.software = 'Nuke'
 
 
 class NukeWindow(NukeCommon, AbstractWindow):
@@ -271,7 +273,6 @@ class NukeWindow(NukeCommon, AbstractWindow):
         if parent is None:
             parent = getMainWindow()
         super(NukeWindow, self).__init__(parent, **kwargs)
-        self.nuke = True
 
         self.__windowHidden = False
         self.setDockable(dockable, override=True)
@@ -402,9 +403,9 @@ class NukeWindow(NukeCommon, AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'nuke' not in self.windowSettings:
-            self.windowSettings['nuke'] = {}
-        settings = self.windowSettings['nuke']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
         settings['docked'] = self.dockable(raw=True)
 
         key = self._getSettingsKey()
@@ -435,7 +436,7 @@ class NukeWindow(NukeCommon, AbstractWindow):
         if self.dockable():
             return
         try:
-            settings = self.windowSettings['nuke']['main']
+            settings = self.windowSettings[self.software]['main']
             x = settings['x']
             y = settings['y']
             width = settings['width']
@@ -740,9 +741,9 @@ class NukeWindow(NukeCommon, AbstractWindow):
 
         #Load settings
         try:
-            nukeSettings = settings['nuke']
+            nukeSettings = settings[self.software]
         except KeyError:
-            nukeSettings = settings['nuke'] = {}
+            nukeSettings = settings[self.software] = {}
 
         if hasattr(cls, 'WindowDockable'):
             docked = cls.WindowDockable
@@ -822,7 +823,6 @@ class NukeBatchWindow(NukeCommon, StandaloneWindow):
     """Variant of the Standalone window for Nuke in batch mode."""
     def __init__(self, parent=None, **kwargs):
         super(NukeBatchWindow, self).__init__(parent, **kwargs)
-        self.nuke = False
         self.batch = True
         self.standalone = False
 
@@ -832,9 +832,9 @@ class NukeBatchWindow(NukeCommon, StandaloneWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'nuke' not in self.windowSettings:
-            self.windowSettings['nuke'] = {}
-        settings = self.windowSettings['nuke']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -855,10 +855,10 @@ class NukeBatchWindow(NukeCommon, StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings['nuke'][key]['width']
-            height = self.windowSettings['nuke'][key]['height']
-            x = self.windowSettings['nuke'][key]['x']
-            y = self.windowSettings['nuke'][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
         except KeyError:
             super(NukeBatchWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/nuke.py
+++ b/vfxwindow/nuke.py
@@ -229,7 +229,7 @@ class Pane(object):
 class NukeCommon(object):
 
     @property
-    def software(self):
+    def application(self):
         return 'Nuke'
 
     def __init__(self, *args, **kwargs):
@@ -278,7 +278,7 @@ class NukeWindow(NukeCommon, AbstractWindow):
             parent = getMainWindow()
         super(NukeWindow, self).__init__(parent, **kwargs)
 
-        self.nuke = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.    
+        self.nuke = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
 
         self.__windowHidden = False
         self.setDockable(dockable, override=True)
@@ -409,9 +409,9 @@ class NukeWindow(NukeCommon, AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
         settings['docked'] = self.dockable(raw=True)
 
         key = self._getSettingsKey()
@@ -442,7 +442,7 @@ class NukeWindow(NukeCommon, AbstractWindow):
         if self.dockable():
             return
         try:
-            settings = self.windowSettings[self.software]['main']
+            settings = self.windowSettings[self.application]['main']
             x = settings['x']
             y = settings['y']
             width = settings['width']
@@ -747,9 +747,9 @@ class NukeWindow(NukeCommon, AbstractWindow):
 
         #Load settings
         try:
-            nukeSettings = settings[self.software]
+            nukeSettings = settings[self.application]
         except KeyError:
-            nukeSettings = settings[self.software] = {}
+            nukeSettings = settings[self.application] = {}
 
         if hasattr(cls, 'WindowDockable'):
             docked = cls.WindowDockable
@@ -830,8 +830,8 @@ class NukeBatchWindow(NukeCommon, StandaloneWindow):
     def __init__(self, parent=None, **kwargs):
         super(NukeBatchWindow, self).__init__(parent, **kwargs)
 
-        self.nuke = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+        self.nuke = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.application`.
 
         self.batch = True
 
@@ -841,9 +841,9 @@ class NukeBatchWindow(NukeCommon, StandaloneWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -864,10 +864,10 @@ class NukeBatchWindow(NukeCommon, StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
         except KeyError:
             super(NukeBatchWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/nuke.py
+++ b/vfxwindow/nuke.py
@@ -227,9 +227,13 @@ class Pane(object):
 
 
 class NukeCommon(object):
+
+    @property
+    def software(self):
+        return 'Nuke'
+
     def __init__(self, *args, **kwargs):
         super(NukeCommon, self).__init__(*args, **kwargs)
-        self.software = 'Nuke'
 
 
 class NukeWindow(NukeCommon, AbstractWindow):

--- a/vfxwindow/standalone.py
+++ b/vfxwindow/standalone.py
@@ -37,7 +37,8 @@ class StandaloneWindow(AbstractWindow):
 
     def __init__(self, parent=None):
         super(StandaloneWindow, self).__init__(parent)
-        self.standalone = True
+        
+        self.standalone = True  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
 
     @property
     def software(self):

--- a/vfxwindow/standalone.py
+++ b/vfxwindow/standalone.py
@@ -37,11 +37,11 @@ class StandaloneWindow(AbstractWindow):
 
     def __init__(self, parent=None):
         super(StandaloneWindow, self).__init__(parent)
-        
-        self.standalone = True  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+
+        self.standalone = True  #: .. deprecated:: 1.9.0
 
     @property
-    def software(self):
+    def application(self):
         return 'Standalone'
 
     @hybridmethod
@@ -121,9 +121,9 @@ class StandaloneWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -140,10 +140,10 @@ class StandaloneWindow(AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
         except KeyError:
             super(StandaloneWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/standalone.py
+++ b/vfxwindow/standalone.py
@@ -39,6 +39,10 @@ class StandaloneWindow(AbstractWindow):
         super(StandaloneWindow, self).__init__(parent)
         self.standalone = True
 
+    @property
+    def software(self):
+        return 'Standalone'
+
     @hybridmethod
     def show(cls, self, *args, **kwargs):
         """Start a standalone QApplication and launch the window.
@@ -116,9 +120,9 @@ class StandaloneWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'standalone' not in self.windowSettings:
-            self.windowSettings['standalone'] = {}
-        settings = self.windowSettings['standalone']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -135,10 +139,10 @@ class StandaloneWindow(AbstractWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            x = self.windowSettings['standalone'][key]['x']
-            y = self.windowSettings['standalone'][key]['y']
-            width = self.windowSettings['standalone'][key]['width']
-            height = self.windowSettings['standalone'][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
         except KeyError:
             super(StandaloneWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/substance_designer.py
+++ b/vfxwindow/substance_designer.py
@@ -91,7 +91,7 @@ class SubstanceDesignerWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstanceDesignerWindow, self).__init__(parent, **kwargs)
 
-        self.substanceDesigner = True
+        self.software = "Substance Designer"
         self.setDockable(dockable, override=True)
 
     def y(self):
@@ -133,9 +133,9 @@ class SubstanceDesignerWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'substance' not in self.windowSettings:
-            self.windowSettings['substance'] = {}
-        settings = self.windowSettings['substance']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
         settings['docked'] = self.dockable(raw=True)
 
         # Save docked settings
@@ -163,10 +163,10 @@ class SubstanceDesignerWindow(AbstractWindow):
 
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings['substance'][key]['width']
-            height = self.windowSettings['substance'][key]['height']
-            x = self.windowSettings['substance'][key]['x']
-            y = self.windowSettings['substance'][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
         except KeyError:
             super(SubstanceDesignerWindow, self).loadWindowPosition()
         else:
@@ -248,7 +248,7 @@ class SubstanceDesignerWindow(AbstractWindow):
             docked = cls.WindowDockable
         else:
             try:
-                docked = settings['substance']['docked']
+                docked = settings[self.software]['docked']
             except KeyError:
                 try:
                     docked = cls.WindowDefaults['docked']
@@ -257,9 +257,9 @@ class SubstanceDesignerWindow(AbstractWindow):
 
         #Load settings
         try:
-            substanceSettings = settings['substance']
+            substanceSettings = settings[self.software]
         except KeyError:
-            substanceSettings = settings['substance'] = {}
+            substanceSettings = settings[self.software] = {}
 
         if docked:
             return dockWrap(cls, *args, **kwargs)

--- a/vfxwindow/substance_designer.py
+++ b/vfxwindow/substance_designer.py
@@ -91,8 +91,11 @@ class SubstanceDesignerWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstanceDesignerWindow, self).__init__(parent, **kwargs)
 
-        self.software = "Substance Designer"
         self.setDockable(dockable, override=True)
+
+    @property
+    def software(self):
+        return 'Substance Designer'
 
     def y(self):
         """Apply y offset for dialogs."""

--- a/vfxwindow/substance_designer.py
+++ b/vfxwindow/substance_designer.py
@@ -91,6 +91,8 @@ class SubstanceDesignerWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstanceDesignerWindow, self).__init__(parent, **kwargs)
 
+        self.substanceDesigner = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+
         self.setDockable(dockable, override=True)
 
     @property

--- a/vfxwindow/substance_designer.py
+++ b/vfxwindow/substance_designer.py
@@ -91,12 +91,12 @@ class SubstanceDesignerWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstanceDesignerWindow, self).__init__(parent, **kwargs)
 
-        self.substanceDesigner = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.substanceDesigner = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
 
         self.setDockable(dockable, override=True)
 
     @property
-    def software(self):
+    def application(self):
         return 'Substance Designer'
 
     def y(self):
@@ -138,9 +138,9 @@ class SubstanceDesignerWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
         settings['docked'] = self.dockable(raw=True)
 
         # Save docked settings
@@ -168,10 +168,10 @@ class SubstanceDesignerWindow(AbstractWindow):
 
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
         except KeyError:
             super(SubstanceDesignerWindow, self).loadWindowPosition()
         else:
@@ -253,7 +253,7 @@ class SubstanceDesignerWindow(AbstractWindow):
             docked = cls.WindowDockable
         else:
             try:
-                docked = settings[self.software]['docked']
+                docked = settings[self.application]['docked']
             except KeyError:
                 try:
                     docked = cls.WindowDefaults['docked']
@@ -262,9 +262,9 @@ class SubstanceDesignerWindow(AbstractWindow):
 
         #Load settings
         try:
-            substanceSettings = settings[self.software]
+            substanceSettings = settings[self.application]
         except KeyError:
-            substanceSettings = settings[self.software] = {}
+            substanceSettings = settings[self.application] = {}
 
         if docked:
             return dockWrap(cls, *args, **kwargs)

--- a/vfxwindow/substance_painter.py
+++ b/vfxwindow/substance_painter.py
@@ -61,12 +61,12 @@ class SubstancePainterWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstancePainterWindow, self).__init__(parent, **kwargs)
 
-        self.substancePainter = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.substancePainter = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
 
         self.setDockable(dockable, override=True)
 
     @property
-    def software(self):
+    def application(self):
         return 'Substance Painter'
 
     def deferred(self, func, *args, **kwargs):
@@ -107,9 +107,9 @@ class SubstancePainterWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
         settings['docked'] = self.dockable(raw=True)
 
         # Save docked settings
@@ -137,10 +137,10 @@ class SubstancePainterWindow(AbstractWindow):
 
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
         except KeyError:
             super(SubstancePainterWindow, self).loadWindowPosition()
         else:
@@ -218,9 +218,9 @@ class SubstancePainterWindow(AbstractWindow):
 
         #Load settings
         try:
-            substanceSettings = settings[self.software]
+            substanceSettings = settings[self.application]
         except KeyError:
-            substanceSettings = settings[self.software] = {}
+            substanceSettings = settings[self.application] = {}
 
         if hasattr(cls, 'WindowDockable'):
             docked = cls.WindowDockable

--- a/vfxwindow/substance_painter.py
+++ b/vfxwindow/substance_painter.py
@@ -61,7 +61,7 @@ class SubstancePainterWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstancePainterWindow, self).__init__(parent, **kwargs)
 
-        self.substancePainter = True
+        self.software = 'Substance Painter'
         self.setDockable(dockable, override=True)
 
     def deferred(self, func, *args, **kwargs):
@@ -102,9 +102,9 @@ class SubstancePainterWindow(AbstractWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'substance' not in self.windowSettings:
-            self.windowSettings['substance'] = {}
-        settings = self.windowSettings['substance']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
         settings['docked'] = self.dockable(raw=True)
 
         # Save docked settings
@@ -132,10 +132,10 @@ class SubstancePainterWindow(AbstractWindow):
 
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings['substance'][key]['width']
-            height = self.windowSettings['substance'][key]['height']
-            x = self.windowSettings['substance'][key]['x']
-            y = self.windowSettings['substance'][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
         except KeyError:
             super(SubstancePainterWindow, self).loadWindowPosition()
         else:
@@ -213,9 +213,9 @@ class SubstancePainterWindow(AbstractWindow):
 
         #Load settings
         try:
-            substanceSettings = settings['substance']
+            substanceSettings = settings[self.software]
         except KeyError:
-            substanceSettings = settings['substance'] = {}
+            substanceSettings = settings[self.software] = {}
 
         if hasattr(cls, 'WindowDockable'):
             docked = cls.WindowDockable

--- a/vfxwindow/substance_painter.py
+++ b/vfxwindow/substance_painter.py
@@ -61,8 +61,11 @@ class SubstancePainterWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstancePainterWindow, self).__init__(parent, **kwargs)
 
-        self.software = 'Substance Painter'
         self.setDockable(dockable, override=True)
+
+    @property
+    def software(self):
+        return 'Substance Painter'
 
     def deferred(self, func, *args, **kwargs):
         """Defer a function execution by 1 second.

--- a/vfxwindow/substance_painter.py
+++ b/vfxwindow/substance_painter.py
@@ -61,6 +61,8 @@ class SubstancePainterWindow(AbstractWindow):
             parent = getMainWindow()
         super(SubstancePainterWindow, self).__init__(parent, **kwargs)
 
+        self.substancePainter = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+
         self.setDockable(dockable, override=True)
 
     @property

--- a/vfxwindow/unreal.py
+++ b/vfxwindow/unreal.py
@@ -19,7 +19,6 @@ class UnrealWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(UnrealWindow, self).__init__(parent, **kwargs)
-        self.software = 'Unreal Engine'
         self.standalone = False
 
         # Parenting external windows was only added in 4.20
@@ -27,6 +26,10 @@ class UnrealWindow(StandaloneWindow):
             unreal.parent_external_window_to_slate(self.winId())
         except AttributeError:
             pass
+
+    @property
+    def software(self):
+        return 'Unreal Engine'
 
     def saveWindowPosition(self):
         """Save the window location."""

--- a/vfxwindow/unreal.py
+++ b/vfxwindow/unreal.py
@@ -19,7 +19,9 @@ class UnrealWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(UnrealWindow, self).__init__(parent, **kwargs)
-        self.standalone = False
+        
+        self.unreal = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
 
         # Parenting external windows was only added in 4.20
         try:

--- a/vfxwindow/unreal.py
+++ b/vfxwindow/unreal.py
@@ -19,9 +19,9 @@ class UnrealWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(UnrealWindow, self).__init__(parent, **kwargs)
-        
-        self.unreal = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.software` instead.
-        self.standalone = False  #: .. deprecated:: 1.9.0 Won't be needed anymore when using :property:`~AbstractWindow.software`.
+
+        self.unreal = True  #: .. deprecated:: 1.9.0 Use :property:`~AbstractWindow.application` instead.
+        self.standalone = False  #: .. deprecated:: 1.9.0
 
         # Parenting external windows was only added in 4.20
         try:
@@ -30,14 +30,14 @@ class UnrealWindow(StandaloneWindow):
             pass
 
     @property
-    def software(self):
+    def application(self):
         return 'Unreal Engine'
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if self.software not in self.windowSettings:
-            self.windowSettings[self.software] = {}
-        settings = self.windowSettings[self.software]
+        if self.application not in self.windowSettings:
+            self.windowSettings[self.application] = {}
+        settings = self.windowSettings[self.application]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -54,10 +54,10 @@ class UnrealWindow(StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings[self.software][key]['width']
-            height = self.windowSettings[self.software][key]['height']
-            x = self.windowSettings[self.software][key]['x']
-            y = self.windowSettings[self.software][key]['y']
+            width = self.windowSettings[self.application][key]['width']
+            height = self.windowSettings[self.application][key]['height']
+            x = self.windowSettings[self.application][key]['x']
+            y = self.windowSettings[self.application][key]['y']
         except KeyError:
             super(UnrealWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/unreal.py
+++ b/vfxwindow/unreal.py
@@ -19,7 +19,7 @@ class UnrealWindow(StandaloneWindow):
 
     def __init__(self, parent=None, **kwargs):
         super(UnrealWindow, self).__init__(parent, **kwargs)
-        self.unreal = True
+        self.software = 'Unreal Engine'
         self.standalone = False
 
         # Parenting external windows was only added in 4.20
@@ -30,9 +30,9 @@ class UnrealWindow(StandaloneWindow):
 
     def saveWindowPosition(self):
         """Save the window location."""
-        if 'unreal' not in self.windowSettings:
-            self.windowSettings['unreal'] = {}
-        settings = self.windowSettings['unreal']
+        if self.software not in self.windowSettings:
+            self.windowSettings[self.software] = {}
+        settings = self.windowSettings[self.software]
 
         key = self._getSettingsKey()
         if key not in settings:
@@ -49,10 +49,10 @@ class UnrealWindow(StandaloneWindow):
         """Set the position of the window when loaded."""
         key = self._getSettingsKey()
         try:
-            width = self.windowSettings['unreal'][key]['width']
-            height = self.windowSettings['unreal'][key]['height']
-            x = self.windowSettings['unreal'][key]['x']
-            y = self.windowSettings['unreal'][key]['y']
+            width = self.windowSettings[self.software][key]['width']
+            height = self.windowSettings[self.software][key]['height']
+            x = self.windowSettings[self.software][key]['x']
+            y = self.windowSettings[self.software][key]['y']
         except KeyError:
             super(UnrealWindow, self).loadWindowPosition()
         else:

--- a/vfxwindow/utils/application.py
+++ b/vfxwindow/utils/application.py
@@ -8,7 +8,7 @@ from .. import exceptions
 def __importable(programImport):
     """Test if the given module import string can be imported.
 
-    If the import string of a DCC can be imported, it's likely that we're in the software
+    If the import string of a DCC can be imported, it's likely that we're in the application
     environment. This is not 100% accurate so it should be paired with another test to
     lower the risk of false positive.
 


### PR DESCRIPTION
Hey @huntfx,

I've recently released my project (only the framework for now) but I've been working on the UI as well and I have some changes to propose for your package. Feel free to discuss them :)

- Replace `pymel` with `maya.cmds`: Even if I understand the qualities for pymel, it's not something most people want to work with, it's slow to import and not native, I never worked anywhere where it was used or even tolerated. So to improve the accessibility for `vfxwindow` I think we can safely replace it with the default `maya.cmds`, I kept the namespace `mc` you were already using. I've been testing this almost since my last PR and it seems to work the same, except it's faster to launch.
- Minor change on MayaWindow, I've added support last time for the icon on the floating window and it was working well when the windows start as docked. Unfortunately, if the windows is `dockable` but not `docked`, it was displayed with no icon. This is now fixed.
- Replace the numerous dcc names attributes on the AbstractWindow with an "abstract" property to be implemented on subclass to get the name of the software. It's a "nice name" by default but can be tested using `self.software.lower() == 'maya'` to prevent false positive. The best solution is still to do:
```py
from vfxwindow import software

if software.isMaya(): 
    ...
```

Let me know what you think,

Greg.